### PR TITLE
Prefix service names with extension name to prevent conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ $ composer require oops/slim-nette-bridge
 
 Oops/SlimNetteBridge requires PHP >= 7.1.
 
-You also need to install and register a PSR-11-compatible wrapper for the Nette DI container. SlimNetteBridge is tested with [`arachne/container-adapter`](https://github.com/Arachne/ContainerAdapter).
-
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,14 @@
 		"php": ">= 7.1.0",
 		"nette/di": "^2.4.0",
 		"nette/utils": "^2.4.0",
+		"psr/container": "1.0.0",
 		"slim/slim": "^3.0.0"
 	},
 	"require-dev": {
-		"arachne/container-adapter": "dev-master",
 		"jakub-onderka/php-parallel-lint": "^0.9.0",
 		"nette/bootstrap": "^2.4.0",
 		"nette/tester": "^1.7.0",
-		"phpstan/phpstan": "^0.7.0"
-	},
-	"suggest": {
-		"arachne/container-adapter": "or any other PSR-11 wrapper for Nette DI container"
+		"phpstan/phpstan": "^0.8.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Container/ContainerAdapter.php
+++ b/src/Container/ContainerAdapter.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Oops\SlimNetteBridge\Container;
+
+use Nette\DI\Container;
+use Nette\DI\MissingServiceException;
+use Psr\Container\ContainerInterface;
+
+
+final class ContainerAdapter implements ContainerInterface
+{
+
+	/**
+	 * @var string
+	 */
+	private $prefix;
+
+	/**
+	 * @var Container
+	 */
+	private $container;
+
+
+	public function __construct(string $prefix, Container $container)
+	{
+		$this->prefix = $prefix;
+		$this->container = $container;
+	}
+
+
+	public function get($id)
+	{
+		try {
+			return $this->container->getService($this->prefix($id));
+
+		} catch (MissingServiceException $exception) {
+			throw new ServiceNotFoundException($exception->getMessage(), $exception->getCode(), $exception);
+
+		} catch (\Exception $exception) {
+			throw new ContainerException($exception->getMessage(), $exception->getCode(), $exception);
+		}
+	}
+
+
+	public function has($id)
+	{
+		return $this->container->hasService($this->prefix($id));
+	}
+
+
+	private function prefix(string $id): string
+	{
+		return $this->prefix . '.' . $id;
+	}
+
+}

--- a/src/Container/ContainerException.php
+++ b/src/Container/ContainerException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Oops\SlimNetteBridge\Container;
+
+use Psr\Container\ContainerExceptionInterface;
+
+
+final class ContainerException extends \RuntimeException implements ContainerExceptionInterface
+{
+}

--- a/src/Container/ServiceNotFoundException.php
+++ b/src/Container/ServiceNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Oops\SlimNetteBridge\Container;
+
+use Psr\Container\NotFoundExceptionInterface;
+
+
+final class ServiceNotFoundException extends \InvalidArgumentException implements NotFoundExceptionInterface
+{
+}

--- a/tests/DI/SlimExtensionTest.phpt
+++ b/tests/DI/SlimExtensionTest.phpt
@@ -7,6 +7,7 @@ namespace OopsTests\SlimNetteBridge\DI;
 use Nette\Configurator;
 use Nette\DI\Container;
 use Nette\Utils\ArrayHash;
+use Psr\Container\ContainerInterface;
 use Psr\Http;
 use Slim;
 use Tester\Assert;
@@ -26,17 +27,37 @@ class SlimExtensionTest extends TestCase
 	{
 		$container = $this->createContainer('default');
 
-		Assert::type(ArrayHash::class, $container->getService('settings'));
-		Assert::type(Slim\Interfaces\Http\EnvironmentInterface::class, $container->getService('environment'));
-		Assert::type(Http\Message\RequestInterface::class, $container->getService('request'));
-		Assert::type(Http\Message\ResponseInterface::class, $container->getService('response'));
-		Assert::type(Slim\Router::class, $container->getService('router'));
-		Assert::type(Slim\Handlers\Strategies\RequestResponse::class, $container->getService('foundHandler'));
-		Assert::type(Slim\Handlers\PhpError::class, $container->getService('phpErrorHandler'));
-		Assert::type(Slim\Handlers\Error::class, $container->getService('errorHandler'));
-		Assert::type(Slim\Handlers\NotFound::class, $container->getService('notFoundHandler'));
-		Assert::type(Slim\Handlers\NotAllowed::class, $container->getService('notAllowedHandler'));
-		Assert::type(Slim\CallableResolver::class, $container->getService('callableResolver'));
+		Assert::type(ArrayHash::class, $container->getService('slim.settings'));
+		Assert::type(Slim\Interfaces\Http\EnvironmentInterface::class, $container->getService('slim.environment'));
+		Assert::type(Http\Message\RequestInterface::class, $container->getService('slim.request'));
+		Assert::type(Http\Message\ResponseInterface::class, $container->getService('slim.response'));
+		Assert::type(Slim\Router::class, $container->getService('slim.router'));
+		Assert::type(Slim\Handlers\Strategies\RequestResponse::class, $container->getService('slim.foundHandler'));
+		Assert::type(Slim\Handlers\PhpError::class, $container->getService('slim.phpErrorHandler'));
+		Assert::type(Slim\Handlers\Error::class, $container->getService('slim.errorHandler'));
+		Assert::type(Slim\Handlers\NotFound::class, $container->getService('slim.notFoundHandler'));
+		Assert::type(Slim\Handlers\NotAllowed::class, $container->getService('slim.notAllowedHandler'));
+		Assert::type(Slim\CallableResolver::class, $container->getService('slim.callableResolver'));
+	}
+
+
+	public function testContainerAdapter(): void
+	{
+		$container = $this->createContainer('default');
+		$containerAdapter = $container->getService('slim.containerAdapter');
+
+		Assert::type(ContainerInterface::class, $containerAdapter);
+		Assert::same($container->getService('slim.settings'), $containerAdapter->get('settings'));
+		Assert::same($container->getService('slim.environment'), $containerAdapter->get('environment'));
+		Assert::same($container->getService('slim.request'), $containerAdapter->get('request'));
+		Assert::same($container->getService('slim.response'), $containerAdapter->get('response'));
+		Assert::same($container->getService('slim.router'), $containerAdapter->get('router'));
+		Assert::same($container->getService('slim.foundHandler'), $containerAdapter->get('foundHandler'));
+		Assert::same($container->getService('slim.phpErrorHandler'), $containerAdapter->get('phpErrorHandler'));
+		Assert::same($container->getService('slim.errorHandler'), $containerAdapter->get('errorHandler'));
+		Assert::same($container->getService('slim.notFoundHandler'), $containerAdapter->get('notFoundHandler'));
+		Assert::same($container->getService('slim.notAllowedHandler'), $containerAdapter->get('notAllowedHandler'));
+		Assert::same($container->getService('slim.callableResolver'), $containerAdapter->get('callableResolver'));
 	}
 
 
@@ -45,7 +66,7 @@ class SlimExtensionTest extends TestCase
 		$container = $this->createContainer('settings');
 
 		/** @var ArrayHash $settings */
-		$settings = $container->getService('settings');
+		$settings = $container->getService('slim.settings');
 		Assert::same('1.1', $settings['httpVersion']);
 		Assert::false($settings['addContentLengthHeader']);
 	}

--- a/tests/DI/configurators.neon
+++ b/tests/DI/configurators.neon
@@ -1,5 +1,4 @@
 extensions:
-	- Arachne\ContainerAdapter\DI\ContainerAdapterExtension
 	slim: Oops\SlimNetteBridge\DI\SlimExtension(%debugMode%)
 
 slim:

--- a/tests/DI/default.neon
+++ b/tests/DI/default.neon
@@ -1,3 +1,2 @@
 extensions:
-	- Arachne\ContainerAdapter\DI\ContainerAdapterExtension
 	slim: Oops\SlimNetteBridge\DI\SlimExtension(%debugMode%)

--- a/tests/DI/settings.neon
+++ b/tests/DI/settings.neon
@@ -1,5 +1,4 @@
 extensions:
-	- Arachne\ContainerAdapter\DI\ContainerAdapterExtension
 	slim: Oops\SlimNetteBridge\DI\SlimExtension(%debugMode%)
 
 slim:


### PR DESCRIPTION
Especially `router` might conflict with nette/application's alias.